### PR TITLE
Last Git-Flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jdk:
 
 branches:
   only:
-    - develop
+    - master
 
 before_script:
     - chmod +x gradlew

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,8 @@ apply plugin: 'io.fabric'
 apply from: 'signingConfigs/release.gradle', to: android
 
 def preDexLibs = !project.hasProperty('disablePreDex')
+def gitSha = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
+def buildTime = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
 
 android {
     compileSdkVersion 23
@@ -31,8 +33,8 @@ android {
         minSdkVersion 21
         targetSdkVersion "$target_sdk_version"
         versionCode publish_version_code
-        versionName publish_version_name
-        resValue "string", "version_name", "$publish_version_name ($publish_version_code)"
+        versionName "$publish_version_name-$gitSha"
+        resValue "string", "version_name", "$publish_version_name ($publish_version_code, $gitSha, $buildTime)"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }


### PR DESCRIPTION
developブランチが役に立っていないので、次からはmasterブランチ直でトピックブランチを作る。
イメージはGitHub-Flow。ただし、masterブランチを毎回リリースするのはシンドイので、リリース時はmasterブランチからreleaseブランチを作成する。

* master
常にGoogle Playで公開可能

* topic/〜
masterブランチから作成する。masterへの手動マージは禁止。
プルリクエストでコード再確認＋Travis CIでビルド・テストに成功することがマージ条件。

* release/x.y.z
masterブランチから作成する。masterへの手動マージは禁止。
プルリクエストでコード再確認＋Travis CIでビルド・テストに成功することがマージ条件。
マージ後、タグ・リリースAPK作成。（ここを自動化するかはTODO）