### PR TITLE
Refresh app lists when app killed and restarted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.2
+    - build-tools-26.0.1
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
     #- extra-google-google_play_services

--- a/app/src/androidTest/kotlin/com/nagopy/android/aplin/view/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/nagopy/android/aplin/view/MainActivityTest.kt
@@ -116,6 +116,9 @@ class MainActivityTest {
         clickAll { app ->
             assertTrue(app.packageName.contains("nagopy"), app.toString())
         }
+
+        onView(withId(R.id.search_src_text))
+                .perform(ViewActions.clearText())
     }
 
 

--- a/app/src/main/kotlin/com/nagopy/android/aplin/model/IconHelper.kt
+++ b/app/src/main/kotlin/com/nagopy/android/aplin/model/IconHelper.kt
@@ -62,7 +62,7 @@ constructor(val application: Application, activityManager: ActivityManager) {
                 try {
                     d = packageManager.getApplicationIcon(pkg) as? BitmapDrawable
                 } catch (e: PackageManager.NameNotFoundException) {
-                    Timber.d(e, "Error pkg=%s", pkg)
+                    Timber.v(e, "Error pkg=%s", pkg)
                     it.onSuccess(defaultIcon)
                     return@create
                 }
@@ -72,9 +72,9 @@ constructor(val application: Application, activityManager: ActivityManager) {
                     icon = defaultIcon
                 }
                 iconCache.put(pkg, icon)
-                Timber.d("Add cache. pkg=s%s", pkg)
+                Timber.v("Add cache. pkg=s%s", pkg)
             } else {
-                Timber.d("Cached. pkg=%s", pkg)
+                Timber.v("Cached. pkg=%s", pkg)
             }
             it.onSuccess(icon)
         }

--- a/app/src/test/kotlin/com/nagopy/android/aplin/presenter/AppListPresenterTest.kt
+++ b/app/src/test/kotlin/com/nagopy/android/aplin/presenter/AppListPresenterTest.kt
@@ -81,6 +81,8 @@ class AppListPresenterTest {
     fun setup() {
         MockitoAnnotations.initMocks(this)
         `when`(applications.getApplicationList(Category.ALL)).thenReturn(Single.create { it.onSuccess(mockList) })
+        appListPresenter.defList = mockList
+        appListPresenter.filteredList.addAll(mockList)
     }
 
     @Test

--- a/app/src/test/kotlin/com/nagopy/android/aplin/presenter/AppListPresenterTest.kt
+++ b/app/src/test/kotlin/com/nagopy/android/aplin/presenter/AppListPresenterTest.kt
@@ -27,6 +27,7 @@ import com.nagopy.android.aplin.model.IconHelper
 import com.nagopy.android.aplin.model.UserSettings
 import com.nagopy.android.aplin.view.AppListView
 import com.nagopy.android.aplin.view.AppListViewParent
+import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -79,7 +80,7 @@ class AppListPresenterTest {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
-        `when`(applications.getApplicationList(Category.ALL)).thenReturn(mockList)
+        `when`(applications.getApplicationList(Category.ALL)).thenReturn(Single.create { it.onSuccess(mockList) })
     }
 
     @Test


### PR DESCRIPTION
Bugfix
アプリが一度KILLされてから再起動したとき、リストが表示されない件の修正。
再生成時、Applications.getApplicationList() が Applications.initAppCache() より先に呼ばれてしまう。これだとキャッシュに読み込む前にリスト表示が終わってしまう。
そのため、getApplicationList の中にもキャッシュ読み込みの開始処理を入れるようにした。