### PR TITLE
Replace stale UI dependencies

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -33,7 +33,7 @@ This document provides an overview of all Gradle dependencies used in the Aplin 
 ### Jetpack Compose UI Framework
 - **Compose UI** (1.7.5) - Core Jetpack Compose library for building native Android UI
 - **Compose Material** (1.7.5) - Material Design components for Compose
-- **Compose Material Icons Extended** (1.7.5) - Extended set of Material Design icons for Compose
+- **Compose Material Icons Core** (1.7.5) - Core Material icon set used by the app
 - **Compose UI Tooling Preview** (1.7.5) - Preview support for Compose in Android Studio
 - **Compose UI Tooling** (1.7.5) - Debug tooling for Compose (debug builds only)
 
@@ -50,11 +50,9 @@ This document provides an overview of all Gradle dependencies used in the Aplin 
 ### Data & Preferences
 - **DataStore Preferences** (1.1.1) - Modern replacement for SharedPreferences with type safety and coroutine support
 - **Preference KTX** (1.2.1) - Kotlin extensions for Android preferences
-- **ComposePrefs** (1.0.6) - Preference components built for Jetpack Compose
 
 ### Utilities
 - **Kotlin Reflect** (2.0.21) - Kotlin reflection library for runtime introspection
-- **Accompanist Drawable Painter** (0.36.0) - Utility for using Android drawables in Compose
 - **Logcat** (0.1) - Structured logging library for Android
 
 ### Google Play Services

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     implementation(libs.androidxKtx)
     implementation(libs.composeUi)
     implementation(libs.composeMaterial)
-    implementation(libs.composeMaterialIconsExtended)
+    implementation(libs.composeMaterialIconsCore)
     implementation(libs.composeToolingPreview)
     implementation(libs.lifecycleRuntimeKtx)
     implementation(libs.activityCompose)
@@ -79,7 +79,6 @@ dependencies {
 
     implementation(libs.koinAndroid)
     implementation(libs.kotlinReflect)
-    implementation(libs.accompanistDrawablepainter)
     implementation(libs.logcat)
 
     implementation(libs.navigationCompose)
@@ -96,7 +95,6 @@ dependencies {
     androidTestImplementation(libs.mockkAndroid)
     androidTestImplementation(libs.mockkAgent)
 
-    implementation(libs.composePrefs)
     implementation(libs.datastorePreferences)
 }
 

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/AndroidDrawablePainter.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/AndroidDrawablePainter.kt
@@ -1,0 +1,52 @@
+package com.nagopy.android.aplin.ui.main.compose
+
+import android.graphics.drawable.Drawable
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.roundToInt
+
+@Composable
+internal fun rememberAndroidDrawablePainter(drawable: Drawable): Painter = remember(drawable) { AndroidDrawablePainter(drawable) }
+
+private class AndroidDrawablePainter(
+    private val drawable: Drawable,
+) : Painter() {
+    override val intrinsicSize: Size
+        get() =
+            if (drawable.intrinsicWidth > 0 && drawable.intrinsicHeight > 0) {
+                Size(drawable.intrinsicWidth.toFloat(), drawable.intrinsicHeight.toFloat())
+            } else {
+                Size.Unspecified
+            }
+
+    override fun DrawScope.onDraw() {
+        drawable.setLayoutDirection(
+            if (layoutDirection == LayoutDirection.Rtl) {
+                View.LAYOUT_DIRECTION_RTL
+            } else {
+                View.LAYOUT_DIRECTION_LTR
+            },
+        )
+        drawable.setBounds(
+            0,
+            0,
+            size.width.roundToInt().coerceAtLeast(0),
+            size.height.roundToInt().coerceAtLeast(0),
+        )
+        drawIntoCanvas { canvas ->
+            canvas.save()
+            try {
+                drawable.draw(canvas.nativeCanvas)
+            } finally {
+                canvas.restore()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppList.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppList.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.nagopy.android.aplin.domain.model.PackageModel
 import kotlin.math.min
 
@@ -76,7 +75,7 @@ private fun Item(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Image(
-                painter = rememberDrawablePainter(drawable = pkg.icon),
+                painter = rememberAndroidDrawablePainter(drawable = pkg.icon),
                 contentDescription = "",
                 modifier = Modifier.size(iconSize),
             )

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppSection.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppSection.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -49,7 +49,7 @@ fun SectionHeader(
             modifier = Modifier.weight(1f),
         )
         Icon(
-            imageVector = Icons.Default.ArrowForward,
+            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
             contentDescription = "",
         )
     }

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainAppBar.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainAppBar.kt
@@ -18,7 +18,7 @@ import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -141,7 +141,7 @@ fun DefaultAppBar(
                         navController.popBackStack()
                     }) {
                         Icon(
-                            imageVector = Icons.Default.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",
                         )
                     }
@@ -194,7 +194,7 @@ fun SearchAppBar(
                             navController.popBackStack()
                         }) {
                             Icon(
-                                imageVector = Icons.Default.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "Back",
                             )
                         }

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/VerticalAppList.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/VerticalAppList.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.nagopy.android.aplin.R
 import com.nagopy.android.aplin.domain.model.PackageModel
 import com.nagopy.android.aplin.ui.prefs.DisplayItem
@@ -84,7 +83,7 @@ private fun Item(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Image(
-                painter = rememberDrawablePainter(drawable = pkg.icon),
+                painter = rememberAndroidDrawablePainter(drawable = pkg.icon),
                 contentDescription = "",
                 modifier = Modifier.size(iconSize),
             )

--- a/app/src/main/java/com/nagopy/android/aplin/ui/prefs/PreferenceScreen.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/prefs/PreferenceScreen.kt
@@ -1,46 +1,281 @@
 package com.nagopy.android.aplin.ui.prefs
 
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Checkbox
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
-import com.jamal.composeprefs.ui.PrefsScreen
-import com.jamal.composeprefs.ui.prefs.ListPref
-import com.jamal.composeprefs.ui.prefs.MultiSelectListPref
+import androidx.compose.ui.unit.dp
 import com.nagopy.android.aplin.R
+import com.nagopy.android.aplin.ui.theme.AplinTheme
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun PreferenceScreen() {
-    PrefsScreen(dataStore = LocalContext.current.dataStore) {
-        prefsItem {
-            MultiSelectListPref(
-                key = DisplayItem.KEY,
-                title = stringResource(id = R.string.display_items),
-                entries =
-                    DisplayItem.values().associate {
-                        it.name to stringResource(id = it.labelResId)
-                    },
-            )
-        }
-        prefsItem {
-            ListPref(
-                key = SortOrder.KEY,
-                title = stringResource(id = R.string.pref_sort_order),
-                entries =
-                    SortOrder.values().associate {
-                        it.name to stringResource(id = it.labelResId)
-                    },
-                defaultValue = SortOrder.DEFAULT.name,
-            )
-        }
+    val context = LocalContext.current
+    val userDataStore = remember(context) { UserDataStore(context.dataStore) }
+    val coroutineScope = rememberCoroutineScope()
+    val displayItems by userDataStore.displayItems.collectAsState(initial = emptyList())
+    val sortOrder by userDataStore.sortOrder.collectAsState(initial = SortOrder.DEFAULT)
+
+    PreferenceScreenContent(
+        displayItems = displayItems.toSet(),
+        sortOrder = sortOrder,
+        onDisplayItemsChanged = { selectedItems ->
+            coroutineScope.launch {
+                userDataStore.setDisplayItems(selectedItems)
+            }
+        },
+        onSortOrderChanged = { selectedSortOrder ->
+            coroutineScope.launch {
+                userDataStore.setSortOrder(selectedSortOrder)
+            }
+        },
+    )
+}
+
+@Composable
+private fun PreferenceScreenContent(
+    displayItems: Set<DisplayItem>,
+    sortOrder: SortOrder,
+    onDisplayItemsChanged: (Set<DisplayItem>) -> Unit,
+    onSortOrderChanged: (SortOrder) -> Unit,
+) {
+    val displayItemLabels = DisplayItem.values().associateWith { stringResource(id = it.labelResId) }
+    val sortOrderLabels = SortOrder.values().associateWith { stringResource(id = it.labelResId) }
+    val noItemsSelected = stringResource(id = R.string.pref_no_items_selected)
+    val displayItemsSummary =
+        DisplayItem.values()
+            .filter(displayItems::contains)
+            .joinToString { displayItemLabels.getValue(it) }
+            .ifEmpty { noItemsSelected }
+    val sortOrderSummary = sortOrderLabels.getValue(sortOrder)
+
+    var pendingDisplayItems by remember { mutableStateOf<Set<DisplayItem>?>(null) }
+    var pendingSortOrder by remember { mutableStateOf<SortOrder?>(null) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        PreferenceRow(
+            title = stringResource(id = R.string.display_items),
+            summary = displayItemsSummary,
+            onClick = { pendingDisplayItems = displayItems },
+        )
+        Divider()
+        PreferenceRow(
+            title = stringResource(id = R.string.pref_sort_order),
+            summary = sortOrderSummary,
+            onClick = { pendingSortOrder = sortOrder },
+        )
+        Divider()
+    }
+
+    pendingDisplayItems?.let { selectedItems ->
+        DisplayItemsDialog(
+            selectedItems = selectedItems,
+            labels = displayItemLabels,
+            onSelectionChanged = { pendingDisplayItems = it },
+            onConfirm = {
+                onDisplayItemsChanged(selectedItems)
+                pendingDisplayItems = null
+            },
+            onDismiss = { pendingDisplayItems = null },
+        )
+    }
+
+    pendingSortOrder?.let { selectedSortOrder ->
+        SortOrderDialog(
+            selectedSortOrder = selectedSortOrder,
+            labels = sortOrderLabels,
+            onSelectionChanged = { pendingSortOrder = it },
+            onConfirm = {
+                onSortOrderChanged(selectedSortOrder)
+                pendingSortOrder = null
+            },
+            onDismiss = { pendingSortOrder = null },
+        )
     }
 }
 
-@Preview
+@Composable
+private fun PreferenceRow(
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(role = Role.Button, onClick = onClick)
+                .semantics(mergeDescendants = true) {
+                    stateDescription = summary
+                }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.subtitle1,
+        )
+        Text(
+            text = summary,
+            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+            style = MaterialTheme.typography.body2,
+        )
+    }
+}
+
+@Composable
+private fun DisplayItemsDialog(
+    selectedItems: Set<DisplayItem>,
+    labels: Map<DisplayItem, String>,
+    onSelectionChanged: (Set<DisplayItem>) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.display_items)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                DisplayItem.values().forEach { item ->
+                    val selected = item in selectedItems
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .toggleable(
+                                    value = selected,
+                                    role = Role.Checkbox,
+                                    onValueChange = {
+                                        onSelectionChanged(toggleDisplayItem(selectedItems, item))
+                                    },
+                                )
+                                .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = selected,
+                            onCheckedChange = null,
+                            modifier = Modifier.clearAndSetSemantics { },
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(text = labels.getValue(item))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(id = android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = android.R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun SortOrderDialog(
+    selectedSortOrder: SortOrder,
+    labels: Map<SortOrder, String>,
+    onSelectionChanged: (SortOrder) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.pref_sort_order)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                SortOrder.values().forEach { sortOrder ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = sortOrder == selectedSortOrder,
+                                    role = Role.RadioButton,
+                                    onClick = { onSelectionChanged(sortOrder) },
+                                )
+                                .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = sortOrder == selectedSortOrder,
+                            onClick = null,
+                            modifier = Modifier.clearAndSetSemantics { },
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(text = labels.getValue(sortOrder))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(id = android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = android.R.string.cancel))
+            }
+        },
+    )
+}
+
+internal fun toggleDisplayItem(
+    selectedItems: Set<DisplayItem>,
+    item: DisplayItem,
+): Set<DisplayItem> =
+    if (item in selectedItems) {
+        selectedItems - item
+    } else {
+        selectedItems + item
+    }
+
+@Preview(showBackground = true)
 @Composable
 fun PreferenceScreenPreview() {
-    PreferenceScreen()
+    AplinTheme {
+        PreferenceScreenContent(
+            displayItems = setOf(DisplayItem.FirstInstallTime, DisplayItem.VersionName),
+            sortOrder = SortOrder.DEFAULT,
+            onDisplayItemsChanged = {},
+            onSortOrderChanged = {},
+        )
+    }
 }

--- a/app/src/main/java/com/nagopy/android/aplin/ui/prefs/UserDataStore.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/prefs/UserDataStore.kt
@@ -3,13 +3,14 @@ package com.nagopy.android.aplin.ui.prefs
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class UserDataStore(dataStore: DataStore<Preferences>) {
+class UserDataStore(private val dataStore: DataStore<Preferences>) {
     private val displayItemsKey = stringSetPreferencesKey(DisplayItem.KEY)
     private val sortOrderKey = stringPreferencesKey(SortOrder.KEY)
 
@@ -24,6 +25,18 @@ class UserDataStore(dataStore: DataStore<Preferences>) {
         dataStore.data.map { it[sortOrderKey] ?: SortOrder.DEFAULT.name }.map {
             SortOrder.values().firstOrNull { item -> item.name == it } ?: SortOrder.DEFAULT
         }
+
+    suspend fun setDisplayItems(displayItems: Set<DisplayItem>) {
+        dataStore.edit { preferences ->
+            preferences[displayItemsKey] = displayItems.mapTo(mutableSetOf()) { it.name }
+        }
+    }
+
+    suspend fun setSortOrder(sortOrder: SortOrder) {
+        dataStore.edit { preferences ->
+            preferences[sortOrderKey] = sortOrder.name
+        }
+    }
 }
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -15,6 +15,7 @@
     <string name="display_item_first_install_time">初回インストール日時</string>
     <string name="display_item_last_update_time">最終更新日時</string>
     <string name="display_item_version_name">バージョン名</string>
+    <string name="pref_no_items_selected">選択なし</string>
 
     <string name="first_install_time_format">初回インストール：%s</string>
     <string name="last_update_time_format">最終更新：%s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="display_item_first_install_time">First install time</string>
     <string name="display_item_last_update_time">Last update time</string>
     <string name="display_item_version_name">Version name</string>
+    <string name="pref_no_items_selected">None selected</string>
 
     <string name="first_install_time_format">First install: %s</string>
     <string name="last_update_time_format">Last update: %s</string>

--- a/app/src/test/java/com/nagopy/android/aplin/ui/prefs/PreferenceSelectionTest.kt
+++ b/app/src/test/java/com/nagopy/android/aplin/ui/prefs/PreferenceSelectionTest.kt
@@ -1,0 +1,24 @@
+package com.nagopy.android.aplin.ui.prefs
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreferenceSelectionTest {
+    @Test
+    fun toggleDisplayItem_addsUnselectedItem() {
+        val selectedItems = setOf(DisplayItem.FirstInstallTime)
+
+        val result = toggleDisplayItem(selectedItems, DisplayItem.VersionName)
+
+        assertEquals(setOf(DisplayItem.FirstInstallTime, DisplayItem.VersionName), result)
+    }
+
+    @Test
+    fun toggleDisplayItem_removesSelectedItem() {
+        val selectedItems = setOf(DisplayItem.FirstInstallTime, DisplayItem.VersionName)
+
+        val result = toggleDisplayItem(selectedItems, DisplayItem.FirstInstallTime)
+
+        assertEquals(setOf(DisplayItem.VersionName), result)
+    }
+}

--- a/app/src/test/java/com/nagopy/android/aplin/ui/prefs/UserDataStoreTest.kt
+++ b/app/src/test/java/com/nagopy/android/aplin/ui/prefs/UserDataStoreTest.kt
@@ -1,0 +1,93 @@
+package com.nagopy.android.aplin.ui.prefs
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class UserDataStoreTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var dataStoreScope: CoroutineScope
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var userDataStore: UserDataStore
+
+    @Before
+    fun setUp() {
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        dataStore =
+            PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                File(temporaryFolder.root, "settings.preferences_pb")
+            }
+        userDataStore = UserDataStore(dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        dataStoreScope.cancel()
+    }
+
+    @Test
+    fun defaults_matchExistingSettingsBehavior() =
+        runBlocking {
+            assertEquals(emptyList<DisplayItem>(), userDataStore.displayItems.first())
+            assertEquals(SortOrder.DEFAULT, userDataStore.sortOrder.first())
+        }
+
+    @Test
+    fun setDisplayItems_storesEnumNamesInExistingStringSet() =
+        runBlocking {
+            val selectedItems = setOf(DisplayItem.FirstInstallTime, DisplayItem.VersionName)
+
+            userDataStore.setDisplayItems(selectedItems)
+
+            val preferences = dataStore.data.first()
+            assertEquals(
+                setOf("FirstInstallTime", "VersionName"),
+                preferences[stringSetPreferencesKey(DisplayItem.KEY)],
+            )
+            assertEquals(selectedItems, userDataStore.displayItems.first().toSet())
+        }
+
+    @Test
+    fun setSortOrder_storesEnumNameInExistingStringPreference() =
+        runBlocking {
+            userDataStore.setSortOrder(SortOrder.LastUpdateTimeDesc)
+
+            val preferences = dataStore.data.first()
+            assertEquals(
+                "LastUpdateTimeDesc",
+                preferences[stringPreferencesKey(SortOrder.KEY)],
+            )
+            assertEquals(SortOrder.LastUpdateTimeDesc, userDataStore.sortOrder.first())
+        }
+
+    @Test
+    fun unknownStoredValues_keepExistingFallbackBehavior() =
+        runBlocking {
+            dataStore.edit { preferences ->
+                preferences[stringSetPreferencesKey(DisplayItem.KEY)] =
+                    setOf(DisplayItem.VersionName.name, "RemovedDisplayItem")
+                preferences[stringPreferencesKey(SortOrder.KEY)] = "RemovedSortOrder"
+            }
+
+            assertEquals(listOf(DisplayItem.VersionName), userDataStore.displayItems.first())
+            assertEquals(SortOrder.DEFAULT, userDataStore.sortOrder.first())
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ androidxTestRules = "1.6.1"
 androidxTestUiautomator = "2.3.0"
 koinAndroid = "4.0.0"
 kotlinReflect = "2.0.21"
-accompanistDrawablepainter = "0.36.0"
 logcat = "0.1"
 navigationCompose = "2.8.4"
 ossLicensesPluginVersion = "0.10.6"
@@ -40,7 +39,6 @@ preferenceKtx = "1.2.1"
 mockk = "1.13.13"
 mockkAndroid = "1.13.13"
 mockkAgent = "1.13.13"
-composePrefs = "1.0.6"
 datastorePreferences = "1.1.1"
 
 [plugins]
@@ -56,7 +54,7 @@ ossLicenses = { group = "com.google.android.gms", name = "oss-licenses-plugin", 
 androidxKtx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 composeUi = { group = "androidx.compose.ui", name = "ui", version.ref = "composeUi" }
 composeMaterial = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial" }
-composeMaterialIconsExtended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "composeMaterial" }
+composeMaterialIconsCore = { group = "androidx.compose.material", name = "material-icons-core", version.ref = "composeMaterial" }
 composeToolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeToolingPreview" }
 lifecycleRuntimeKtx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 activityCompose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -71,7 +69,6 @@ androidxComposeUiTestJunit4 = { group = "androidx.compose.ui", name = "ui-test-j
 androidxComposeUiTooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUi" }
 koinAndroid = { group = "io.insert-koin", name = "koin-android", version.ref = "koinAndroid" }
 kotlinReflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlinReflect" }
-accompanistDrawablepainter = { group = "com.google.accompanist", name = "accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
 logcat = { group = "com.squareup.logcat", name = "logcat", version.ref = "logcat" }
 navigationCompose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPluginVersion" }
@@ -83,5 +80,4 @@ preferenceKtx = { group = "androidx.preference", name = "preference-ktx", versio
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockkAndroid = { group = "io.mockk", name = "mockk-android", version.ref = "mockkAndroid" }
 mockkAgent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockkAgent" }
-composePrefs = { group = "com.github.JamalMulla", name = "ComposePrefs", version.ref = "composePrefs" }
 datastorePreferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
     }
 }
 rootProject.name = "Aplin"


### PR DESCRIPTION
## Summary

- replace unmaintained ComposePrefs with a first-party Compose settings screen while preserving existing DataStore keys and serialized enum names
- replace Accompanist DrawablePainter with a small local painter and switch from extended to core Material icons
- remove the JitPack repository and add focused preference persistence tests

## Verification

- ANDROID_HOME=/Users/tom/Library/Android/sdk ./gradlew --no-daemon ktlintCheck testDebugUnitTest lintRelease bundleRelease
- API 37 emulator: settings dialogs render, selections persist across process restart, and bitmap/vector/adaptive application icons render correctly

This is a preparatory change for the dependency refresh and play/foss flavor split.