### PR TITLE
Clarify app category labels

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <string name="app_name">Aplin</string>
 
-    <string name="category_users">アンインストールできるアプリ</string>
-    <string name="category_disableable">無効にできるアプリ</string>
+    <string name="category_users">非システムアプリ</string>
+    <string name="category_disableable">無効にできる可能性があるアプリ</string>
     <string name="category_disabled">無効化済みのアプリ</string>
     <string name="category_all">全てのアプリ</string>
     <string name="licenses">オープンソースライセンス</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Aplin</string>
 
-    <string name="category_users">Uninstallable Apps</string>
+    <string name="category_users">Non-system Apps</string>
     <string name="category_disableable">Maybe Disableable Apps</string>
     <string name="category_disabled">Disabled Apps</string>
     <string name="category_all">All Apps</string>


### PR DESCRIPTION
## Summary

- rename the English user-app category from `Uninstallable Apps` to `Non-system Apps`
- rename the Japanese user-app category to `非システムアプリ`
- qualify the Japanese disableable-app category as `無効にできる可能性があるアプリ`

The wording now matches the existing predicates: the user-app list filters out `FLAG_SYSTEM` packages, while the disableable list is based on a conservative best-effort check. No classification behavior changes.

## Verification

- `ktlintCheck`
- `testPlayDebugUnitTest`
- `testFossDebugUnitTest`
- `lintPlayDebug`
- `lintFossDebug`
- `assemblePlayDebug`
- `assembleFossDebug`
- verified the English and Japanese labels on the home screen of an Android 37.1 Pixel Fold emulator
- independent read-only Herdr review: APPROVE
- GitHub Actions: SUCCESS, including the existing test-configured Play release bundle and FOSS release APK validation

No locally signed or publishable AAB was produced.
