### PR TITLE
Fix license screen system bar insets

### DIFF
--- a/app/src/main/java/com/nagopy/android/aplin/ui/licenses/LicensesActivity.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/licenses/LicensesActivity.kt
@@ -3,15 +3,20 @@ package com.nagopy.android.aplin.ui.licenses
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.primarySurface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -22,6 +27,7 @@ import com.nagopy.android.aplin.ui.theme.AplinTheme
 class LicensesActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val entries =
             runCatching { LicenseCatalogLoader(assets).load() }
                 .getOrElse { emptyList() }
@@ -36,16 +42,21 @@ class LicensesActivity : ComponentActivity() {
 @Composable
 private fun LicenseScreen(entries: List<LicenseEntry>) {
     Scaffold(
-        topBar = { TopAppBar(title = { Text(stringResource(R.string.licenses)) }) },
+        topBar = {
+            TopAppBar(
+                modifier = Modifier.background(MaterialTheme.colors.primarySurface).statusBarsPadding(),
+                title = { Text(stringResource(R.string.licenses)) },
+            )
+        },
     ) { padding ->
         if (entries.isEmpty()) {
             Text(
                 text = stringResource(R.string.licenses_unavailable),
-                modifier = Modifier.padding(padding).padding(16.dp),
+                modifier = Modifier.padding(padding).navigationBarsPadding().padding(16.dp),
             )
         } else {
             LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(padding),
+                modifier = Modifier.fillMaxSize().padding(padding).navigationBarsPadding(),
             ) {
                 items(entries) { entry ->
                     LicenseRow(entry)


### PR DESCRIPTION
## Summary

- opt `LicensesActivity` into edge-to-edge rendering
- inset the Material 2 top app bar below the status bar and display cutout
- keep the license list and empty state above the navigation bar

This is intentionally a standalone UI fix and is independent of the F-Droid readiness work in #357.

## Verification

- `ktlintCheck`
- `testPlayDebugUnitTest`
- `testFossDebugUnitTest`
- `lintPlayDebug`
- `lintFossDebug`
- `assemblePlayDebug`
- `assembleFossDebug`
- visually verified on an Android 37.1 Pixel Fold emulator inner display; UI hierarchy confirmed that the app bar and content do not overlap the status or navigation bars
- independent read-only Herdr review: APPROVE
- GitHub Actions: SUCCESS, including the existing test-configured Play release bundle and FOSS release APK validation

No locally signed or publishable AAB was produced.
