### PR TITLE
Use wide screens more effectively in app lists; collapse app bar actions into overflow menu

### DIFF
--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/AppListScreen.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/AppListScreen.kt
@@ -38,6 +38,7 @@ fun AppListScreen(
 @Preview(name = "5-inch Device Landscape", widthDp = 640, heightDp = 360)
 @Preview(name = "10-inch Tablet Portrait", widthDp = 600, heightDp = 960)
 @Preview(name = "10-inch Tablet Landscape", widthDp = 960, heightDp = 600)
+@Preview(name = "Foldable Inner Portrait", widthDp = 840, heightDp = 900)
 @Composable
 fun AppListScreenLoadedPreview() {
     val packages =

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppList.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/HorizontalAppList.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import androidx.compose.ui.unit.sp
 import com.nagopy.android.aplin.domain.model.PackageModel
 import kotlin.math.min
@@ -35,11 +36,11 @@ fun HorizontalAppList(
 ) {
     val lc = LocalConfiguration.current
     val itemWidth =
-        remember {
-            min(lc.screenWidthDp, lc.screenHeightDp).dp / 2.6f
+        remember(lc.screenWidthDp, lc.screenHeightDp) {
+            min(min(lc.screenWidthDp, lc.screenHeightDp).dp / 2.6f, 160.dp)
         }
     val iconSize =
-        remember {
+        remember(lc.screenWidthDp, lc.screenHeightDp) {
             itemWidth / 2.0f
         }
     LazyRow {

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainAppBar.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainAppBar.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -20,13 +22,14 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.primarySurface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
@@ -35,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -91,46 +95,54 @@ fun DefaultAppBar(
                 .background(MaterialTheme.colors.primarySurface)
                 .statusBarsPadding(),
         title = {
-            Text(text = stringResource(id = currentScreen.resourceId))
+            Text(
+                text = stringResource(id = currentScreen.resourceId),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         },
         actions = {
             if (state.isLoading && state.packagesModel != null) {
                 CircularProgressIndicator(color = Color.LightGray)
             }
 
-            if (currentScreen is Screen.AppListScreen && state.packagesModel != null) {
-                IconButton(onClick = {
-                    sharePackages.invoke(
-                        currentScreen.getAppList(
-                            state.packagesModel,
-                            state.searchText,
-                        ),
-                    )
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.Share,
-                        contentDescription = stringResource(id = R.string.share),
-                    )
-                }
-            }
-
             if (currentScreen !is Screen.Preferences) {
-                IconButton(onClick = {
-                    onSearchTriggered()
-                }) {
+                var menuExpanded by remember { mutableStateOf(false) }
+                IconButton(onClick = { menuExpanded = true }) {
                     Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = stringResource(id = R.string.search),
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = stringResource(id = R.string.more_options),
                     )
                 }
-
-                IconButton(onClick = {
-                    navController.navigate(Screen.Preferences.route)
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.Settings,
-                        contentDescription = stringResource(id = R.string.preferences),
-                    )
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false },
+                ) {
+                    if (currentScreen is Screen.AppListScreen && state.packagesModel != null) {
+                        DropdownMenuItem(onClick = {
+                            menuExpanded = false
+                            sharePackages.invoke(
+                                currentScreen.getAppList(
+                                    state.packagesModel,
+                                    state.searchText,
+                                ),
+                            )
+                        }) {
+                            Text(text = stringResource(id = R.string.share))
+                        }
+                    }
+                    DropdownMenuItem(onClick = {
+                        menuExpanded = false
+                        onSearchTriggered()
+                    }) {
+                        Text(text = stringResource(id = R.string.search))
+                    }
+                    DropdownMenuItem(onClick = {
+                        menuExpanded = false
+                        navController.navigate(Screen.Preferences.route)
+                    }) {
+                        Text(text = stringResource(id = R.string.preferences))
+                    }
                 }
             }
         },

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainScreen.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/MainScreen.kt
@@ -97,6 +97,7 @@ fun MainScreenLoaded(
 @Preview(name = "5-inch Device Landscape", widthDp = 640, heightDp = 360)
 @Preview(name = "10-inch Tablet Portrait", widthDp = 600, heightDp = 960)
 @Preview(name = "10-inch Tablet Landscape", widthDp = 960, heightDp = 600)
+@Preview(name = "Foldable Inner Portrait", widthDp = 840, heightDp = 900)
 @Composable
 fun MainScreenLoadedPreview() {
     val packages =

--- a/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/VerticalAppList.kt
+++ b/app/src/main/java/com/nagopy/android/aplin/ui/main/compose/VerticalAppList.kt
@@ -13,8 +13,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -50,7 +51,10 @@ fun VerticalAppList(
     val displayItems =
         UserDataStore(LocalContext.current.dataStore).displayItems.collectAsState(initial = emptyList())
     val iconSize = with(LocalDensity.current) { launcherLargeIconSize.toDp() }
-    LazyColumn(modifier) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 400.dp),
+        modifier = modifier,
+    ) {
         items(packages) { pkg ->
             Item(startDetailSettingsActivity, searchByWeb, iconSize, displayItems.value, pkg)
         }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,6 +17,7 @@
     <string name="web_search_unavailable">ウェブ検索アプリが見つかりません。</string>
     <string name="share">共有</string>
     <string name="search">検索</string>
+    <string name="more_options">その他のオプション</string>
     <string name="search_hint">アプリ名・パッケージ名で検索する</string>
 
     <string name="preferences">設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="change_consent_state" translatable="false">Change consent state</string>
     <string name="share">Share</string>
     <string name="search">Search</string>
+    <string name="more_options">More options</string>
     <string name="search_hint">Search…</string>
 
     <string name="preferences">Preferences</string>


### PR DESCRIPTION
## Summary
On wide screens (e.g. Pixel Fold inner display, ~840dp) the lists rendered correctly but wasted space: home-screen cards were sized as `min(w,h)/2.6` (~320dp each, 2–3 per row) and category lists were a single full-width column.

- `HorizontalAppList`: card width is now `min(min(w,h)/2.6, 160dp)` and `remember` is keyed on the configuration so fold/unfold recomputes. Phones (360dp → 138dp) are unchanged; wide screens show ~5 cards per row.
- `VerticalAppList`: `LazyColumn` → `LazyVerticalGrid(GridCells.Adaptive(minSize = 400.dp))`, giving 1 column on phones / 600dp tablets and 2 columns at ≥800dp.
- Added an 840×900dp "Foldable Inner Portrait" `@Preview` to `MainScreenLoadedPreview` and `AppListScreenLoadedPreview`.

Also (found during emulator testing at 360dp): long screen titles like "Maybe Disableable Apps" wrapped and clipped in the app bar because of the three action icons.
- `DefaultAppBar`: title is `maxLines = 1` / `Ellipsis`, and Share / Search / Preferences are moved into a single `⋮` `DropdownMenu` (Share still only appears on `AppListScreen`s; the menu is hidden on `Preferences` as before). New string `more_options` (en/ja).

Verified with `ktlintCheck` + `compileFossDebugKotlin` locally and on emulator (see PR comment).

Link to Devin session: https://app.devin.ai/sessions/e54f4f60f3984f0baadceb23ede2313b
Open in Devin Desktop: https://app.devin.ai/desktop/session/e54f4f60f3984f0baadceb23ede2313b?variant=devin
Requested by: @75py